### PR TITLE
Update news_preprocess.py

### DIFF
--- a/data_preprocess/news_preprocess.py
+++ b/data_preprocess/news_preprocess.py
@@ -40,7 +40,7 @@ def save_word_embeddings(column_words, newsid, file_name):
     split = split.apply(lambda x: [i.rstrip(',.!?\'\"') for i in x])
     split = split.apply(lambda x: [i.lstrip(',.!?\'\"') for i in x])
     words = split.tolist()
-    word_vocab = list(set(np.concatenate(np.array(words))))
+    word_vocab = list(set([word for sublist in words for word in sublist]))
 
     "save word embeddings from glove"
     f = open('../glove/glove_dict.pkl', 'rb')


### PR DESCRIPTION
Instead of using np.concatenate, try using a list comprehension to flatten your nested list. Ensure that none of the sublists in your words list are empty. An empty sublist can also cause issues when creating a NumPy array.